### PR TITLE
Add missing license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # options.js #
 
 A very light-weight in-code option parsers for node.js.
+
+## License ##
+
+(The MIT License)
+
+Copyright (c) 2012 Einar Otto Stangvik &lt;einaros@gmail.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,3 +1,8 @@
+/*!
+ * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+ * MIT Licensed
+ */
+
 var fs = require('fs');
 
 function Options(defaults) {


### PR DESCRIPTION
Assuming options.js is to be distributed under the same terms as some of your other repositories' licences I've added the missing license stuff. Without this it's not possible for certain projects to distribute your code..
