### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "name": "options",
   "description": "A very light-weight in-code option parsers for node.js.",
   "version": "0.0.6",
+  "licenses" : [
+    {
+      "type" : "MIT",
+      "url" : "https://raw.githubusercontent.com/einaros/options.js/master/README.md"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/einaros/options.js.git"


### PR DESCRIPTION
Allows license to be read programatically.
