### PR TITLE
Fix bug when calling .copy with single string value

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -49,6 +49,9 @@ function Options(defaults) {
     return this;
   };
   this.copy = function(keys) {
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
     var obj = {};
     Object.keys(defaults).forEach(function(key) {
       if (keys.indexOf(key) !== -1) {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -65,6 +65,12 @@ describe('Options', function() {
       assert.strictEqual(4, obj.c);
       assert.strictEqual('undefined', typeof obj.b);
     });
+    it('returns only the indicated option', function() {
+      var option = new Options({a: true, ab: false});
+      var obj = option.copy('ab');
+      assert.strictEqual(false, obj.ab);
+      assert.strictEqual('undefined', typeof obj.a);
+    });
   });
 
   describe('#value', function() {


### PR DESCRIPTION
Consider this:

``` javascript
var option = new Options({a: true, ab: false});
var obj = option.copy('ab');
assert.stringEqual('undefined', typeof obj.a); // Error, obj.a === true
```

this PR fixes it.
