### PR TITLE
Avoiding closure leaks

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -8,26 +8,44 @@ var fs = require('fs');
 function Options(defaults, destroymethodname) {
   var internalValues = {};
   var values = this.value = {};
+  var destroy  = (function (self) {
+    return function () {
+      var v;
+      internalValues = null;
+      for(n in values) {
+        if (values.hasOwnProperty(n)) {
+          v = values[n];// = null;
+        }
+      }
+      values = null;
+      defaults = null;
+      destroymethodname = null;
+      self.reset = null;
+      self.merge = null;
+      self.copy = null;
+      self.read = null;
+      self.isDefined = null;
+      self.isDefinedAndNonNull = null;
+      self.destroy = null;
+      self = null;
+    };
+  })(this);
   Object.keys(defaults).forEach(function(key) {
     internalValues[key] = defaults[key];
     Object.defineProperty(values, key, {
-      get: function() { return internalValues[key]; },
+      get: function() { 
+        if (internalValues) {
+          return internalValues[key];
+        } else {
+          key = null;
+        }
+      },
       configurable: false,
       enumerable: true
     });
   });
   if (destroymethodname) {
-    values[destroymethodname] = function () {
-      var n;
-      internalValues = null;
-      for(n in values) {
-        if (values.hasOwnProperty(n)) {
-          values[n] = null;
-        }
-      }
-      values = null;
-      destroymethodname = null;
-    };
+    values[destroymethodname] = destroy;
   }
   this.reset = function() {
     Object.keys(defaults).forEach(function(key) {
@@ -59,6 +77,7 @@ function Options(defaults, destroymethodname) {
         internalValues[key] = options[key];
       }
     });
+    options = null;
     return this;
   };
   this.copy = function(keys) {
@@ -77,6 +96,7 @@ function Options(defaults, destroymethodname) {
         if (error) return cb(error);
         var conf = JSON.parse(data);
         self.merge(conf);
+        self = null;
         cb();
       });
     }
@@ -84,6 +104,7 @@ function Options(defaults, destroymethodname) {
       var conf = JSON.parse(fs.readFileSync(filename));
       this.merge(conf);
     }
+    cb = null;
     return this;
   };
   this.isDefined = function(key) {
@@ -92,16 +113,7 @@ function Options(defaults, destroymethodname) {
   this.isDefinedAndNonNull = function(key) {
     return typeof values[key] != 'undefined' && values[key] !== null;
   };
-  this.destroy = function () {
-    internalValues = null;
-    for(n in values) {
-      if (values.hasOwnProperty(n)) {
-        values[n] = null;
-      }
-    }
-    values = null;
-    destroymethodname = null;
-  };
+  this.destroy = destroy;
   Object.freeze(values);
   Object.freeze(this);
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -5,7 +5,7 @@
 
 var fs = require('fs');
 
-function Options(defaults) {
+function Options(defaults, destroymethodname) {
   var internalValues = {};
   var values = this.value = {};
   Object.keys(defaults).forEach(function(key) {
@@ -16,6 +16,19 @@ function Options(defaults) {
       enumerable: true
     });
   });
+  if (destroymethodname) {
+    values[destroymethodname] = function () {
+      var n;
+      internalValues = null;
+      for(n in values) {
+        if (values.hasOwnProperty(n)) {
+          values[n] = null;
+        }
+      }
+      values = null;
+      destroymethodname = null;
+    };
+  }
   this.reset = function() {
     Object.keys(defaults).forEach(function(key) {
       internalValues[key] = defaults[key];
@@ -78,6 +91,16 @@ function Options(defaults) {
   };
   this.isDefinedAndNonNull = function(key) {
     return typeof values[key] != 'undefined' && values[key] !== null;
+  };
+  this.destroy = function () {
+    internalValues = null;
+    for(n in values) {
+      if (values.hasOwnProperty(n)) {
+        values[n] = null;
+      }
+    }
+    values = null;
+    destroymethodname = null;
   };
   Object.freeze(values);
   Object.freeze(this);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Einar Otto Stangvik <einaros@gmail.com> (http://2x.io)",
   "name": "options",
   "description": "A very light-weight in-code option parsers for node.js.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "git://github.com/einaros/options.js.git"


### PR DESCRIPTION
Here is a possible solution for avoiding massive memory leaks that occur via closures.
These leaks happen for each property built on the `values` variable. In other words, for every property of the `defaults` object, a leaking closure is created.
In order to overcome such a behavior, the `destroy` method is introduced on the Options object.
Proposed usage:

``` javascript
var options = new Options({width: 1, height: 1});
...
options.destroy();
```

However, in certain use cases, a developer might find useful to "forget" about the Options object and continue using its `values` property object. In such a situation it would be clumsy to drag the reference to the original Options object in order to `destroy` it eventually.
For such cases, another helper is introduced - the `destroymethodname`.
Proposed usage:

``` javascript
function createValues (defaults) {
  var options = new Options(defaults, 'dispose');
  return options.values;
}
function useOptions () {
  var values = createValues({width: 1, height: 1});
  ...
  values.dispose();
}
```

The PR proposed is backwards-compatible - but one should bare in mind that without calling `destroy` on the Options object or the `destroymethodname` on its `values` property, the resulting memory leaks will remain in massive amounts.
