### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "options",
   "description": "A very light-weight in-code option parsers for node.js.",
   "version": "0.0.6",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/einaros/options.js.git"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.